### PR TITLE
Fix two 'undefined control sequence' errors in tufte-handout template

### DIFF
--- a/tufte-handout/src/template.tex
+++ b/tufte-handout/src/template.tex
@@ -21,10 +21,7 @@ $if(euro)$
   \usepackage{eurosym}
 $endif$
 \else % if luatex or xelatex
-  \ifxetex
-  \else
-    \usepackage{fontspec}
-  \fi
+  \usepackage{fontspec}
   \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
 $for(fontfamilies)$
   \newfontfamily{$fontfamilies.name$}[$fontfamilies.options$]{$fontfamilies.font$}
@@ -62,6 +59,7 @@ $endif$
 $if(colorlinks)$
 \PassOptionsToPackage{usenames,dvipsnames}{color} % color is loaded by hyperref
 $endif$
+\usepackage{hyperref}
 \hypersetup{
 $if(title-meta)$
             pdftitle={$title-meta$},


### PR DESCRIPTION
I stumbled upon the following 2 errors when using this template using Manjaro Linux:

```
Error producing PDF.
! Undefined control sequence.
l.14   \defaultfontfeatures
```
and
```
Error producing PDF.
! Undefined control sequence.
l.24 \hypersetup
```

The terminal command used was: `$ pandoc file.md -s --pdf-engine=xelatex --template=tufte-handout -o file.pdf`